### PR TITLE
Adding batching and multi-histogram support

### DIFF
--- a/python/mozfun_local/glam.py
+++ b/python/mozfun_local/glam.py
@@ -53,14 +53,14 @@ def glam_style_histogram(
     keyed -- bool if the histogram is keyed
     date -- string of date you wish to calculate the transformation for (date is a partition key)
     limit -- int of the number of rows from the ping to take (default None/no limit)
-    sample_rate -- float what percent of samples to take per histogram, starting at zero, only divisible by 10, default None
+    sample_rate -- float what percent of samples to take per histogram, starting at zero, only divisible by 20, default None
     table -- full path to the table you wish to take probes from (default mozdata.telemetry.main_1pct)
     """
-    scaled_sample_rate = sample_rate * 100 if sample_rate else 10
+    scaled_sample_rate = sample_rate * 100 if sample_rate else 20
     if sample_rate is not None:
         assert (
-            (scaled_sample_rate) % 10 == 0 and sample_rate > 0.0 and sample_rate <= 1.0
-        ), "sample rate must be between zero and one, and divsible by 10 in whole number representation"
+            (scaled_sample_rate) % 20 == 0 and sample_rate > 0.0 and sample_rate <= 1.0
+        ), "sample rate must be between zero and one, and divsible by 20 in whole number representation"
 
     _limit = f"LIMIT {limit}" if limit else ""
 
@@ -77,7 +77,7 @@ def glam_style_histogram(
     probe_string = (", \n    ").join(probe_locations)
 
     # 0 <= sample_id < 100
-    for f in np.arange(10, scaled_sample_rate + 10, 10):
+    for f in np.arange(20, scaled_sample_rate + 10, 20):
         print(f)
         if sample_rate:
             sample_id_string = (

--- a/python/mozfun_local/glam.py
+++ b/python/mozfun_local/glam.py
@@ -78,7 +78,6 @@ def glam_style_histogram(
 
     # 0 <= sample_id < 100
     for f in np.arange(20, scaled_sample_rate + 10, 20):
-        print(f)
         if sample_rate:
             sample_id_string = (
                 f"AND sample_id >= {int(f - 10)} AND sample_id < {int(f)}"

--- a/python/mozfun_local/glam.py
+++ b/python/mozfun_local/glam.py
@@ -98,14 +98,14 @@ def _lists_from_tuples(tuples):
 
 def _find_cutoffs(buckets, cdf, percentiles):
     assert len(percentiles) > 0, "Must provide at least one percentile to calculate"
-    percentiles = sorted(percentiles) # we only need to go through once
-                                      # if values are sorted
-    
+    percentiles = sorted(percentiles)  # we only need to go through once
+    # if values are sorted
+
     results = {}
     max_iter = len(cdf)
     i = 0
     for p in percentiles:
-        while i < max_iter and cdf[i] < p: 
+        while i < max_iter and cdf[i] < p:
             i += 1
         if i < max_iter:
             results[p] = buckets[i]
@@ -115,7 +115,7 @@ def _find_cutoffs(buckets, cdf, percentiles):
     return results
 
 
-def calculate_percentiles(distribution: list, percentiles: list) -> dict:
+def calculate_percentiles(distribution, percentiles) -> dict:
     """Given a list of percentiles and a distribution, find the buckets that
     represent each percentile. Internal functions are numba jitted python.
 
@@ -125,8 +125,9 @@ def calculate_percentiles(distribution: list, percentiles: list) -> dict:
     percentiles -- list of floating point values [0.0, 1.0] of the percentiles
                    you wish to calculate
     """
+    # perf improvement as we iterate later and numpy has known types
     if type(percentiles) != np.ndarray:
-        percentiles = np.array(percentiles)
+        percentiles = np.array(percentiles)  # type: np.ndarray
 
     k, v = _lists_from_tuples(distribution)
 

--- a/python/mozfun_local/glam.py
+++ b/python/mozfun_local/glam.py
@@ -102,11 +102,13 @@ AND date(submission_timestamp) > date(2022, 12, 20)
         print(f"starting query at {datetime.now()}")
         dataset = bq_client.query(sql_query).result()
         print(f"got data from bq at {datetime.now()}")
-        data = pl.from_arrow(dataset.to_arrow())  # type: pl.DataFrame
+        data = pl.from_arrow(dataset.to_arrow(), rechunk=False)  # type: pl.DataFrame
+        print(f"data moved to arrow and loaded in polars at {datetime.now()}")
 
         for probe in probes:
             df = data.select(["client_id", "build_id", probe])
             df = df.filter(pl.col(probe).is_not_null())
+            print(f"nulls filtered at {datetime.now()}")
 
             metadata = get_metadata(probe)
             print(f"sending {probe} to Rust at {datetime.now()}")

--- a/python/mozfun_local/glam.py
+++ b/python/mozfun_local/glam.py
@@ -40,7 +40,7 @@ def glam_style_histogram(
     keyed: bool,
     date: str,
     limit: int = None,
-    batch_size: float = None,
+    sample_rate: float = None,
     table: str = "mozdata.telemetry.main_1pct",
 ) -> list:
     """Calculate the GLAM style histogram transformation to a given histogram
@@ -53,13 +53,13 @@ def glam_style_histogram(
     keyed -- bool if the histogram is keyed
     date -- string of date you wish to calculate the transformation for (date is a partition key)
     limit -- int of the number of rows from the ping to take (default None/no limit)
-    batch_size -- float what percent of samples to take per batch, starting at zero, only divisible by 10, default None
+    sample_rate -- float what percent of samples to take per histogram, starting at zero, only divisible by 10, default None
     table -- full path to the table you wish to take probes from (default mozdata.telemetry.main_1pct)
     """
-    scaled_batch_size = batch_size * 100 if batch_size else 10
-    if batch_size is not None:
+    scaled_sample_rate = sample_rate * 100 if sample_rate else 10
+    if sample_rate is not None:
         assert (
-            (scaled_batch_size) % 10 == 0 and batch_size > 0.0 and batch_size <= 1.0
+            (scaled_sample_rate) % 10 == 0 and sample_rate > 0.0 and sample_rate <= 1.0
         ), "sample rate must be between zero and one, and divsible by 10 in whole number representation"
 
     _limit = f"LIMIT {limit}" if limit else ""
@@ -77,9 +77,9 @@ def glam_style_histogram(
     probe_string = (", \n    ").join(probe_locations)
 
     # 0 <= sample_id < 100
-    for f in np.arange(10, scaled_batch_size + 10, 10):
+    for f in np.arange(10, scaled_sample_rate + 10, 10):
         print(f)
-        if batch_size:
+        if sample_rate:
             sample_id_string = (
                 f"AND sample_id >= {int(f - 10)} AND sample_id < {int(f)}"
             )

--- a/python/mozfun_local/glam.py
+++ b/python/mozfun_local/glam.py
@@ -80,7 +80,9 @@ def glam_style_histogram(
     for f in np.arange(10, scaled_batch_size + 10, 10):
         print(f)
         if batch_size:
-            sample_id_string = f"AND sample_id >= {int(f - 10)} AND sample_id < {int(f)}"
+            sample_id_string = (
+                f"AND sample_id >= {int(f - 10)} AND sample_id < {int(f)}"
+            )
         else:
             sample_id_string = ""
         sql_query = f"""SELECT 
@@ -106,7 +108,7 @@ AND date(submission_timestamp) > date(2022, 12, 20)
             metadata = get_metadata(probe)
 
             result = _glam_style_histogram(df, metadata)
-            results.append((probe, f, f-10, result))
+            results.append((probe, f, f - 10, result))
 
     return results
 

--- a/python/mozfun_local/glam.py
+++ b/python/mozfun_local/glam.py
@@ -40,7 +40,7 @@ def glam_style_histogram(
     keyed: bool,
     date: str,
     limit: int = None,
-    sample_rate: float = None,
+    batch_size: float = None,
     table: str = "mozdata.telemetry.main_1pct",
 ) -> list:
     """Calculate the GLAM style histogram transformation to a given histogram
@@ -53,13 +53,13 @@ def glam_style_histogram(
     keyed -- bool if the histogram is keyed
     date -- string of date you wish to calculate the transformation for (date is a partition key)
     limit -- int of the number of rows from the ping to take (default None/no limit)
-    sample_rate -- float what percent of samples to take, starting at zero, only divisible by 10, default None
+    batch_size -- float what percent of samples to take per batch, starting at zero, only divisible by 10, default None
     table -- full path to the table you wish to take probes from (default mozdata.telemetry.main_1pct)
     """
-    scaled_sample = sample_rate * 100 if sample_rate else 10
-    if sample_rate is not None:
+    scaled_batch_size = batch_size * 100 if batch_size else 10
+    if batch_size is not None:
         assert (
-            (scaled_sample) % 10 == 0 and sample_rate > 0.0 and sample_rate <= 1.0
+            (scaled_batch_size) % 10 == 0 and batch_size > 0.0 and batch_size <= 1.0
         ), "sample rate must be between zero and one, and divsible by 10 in whole number representation"
 
     _limit = f"LIMIT {limit}" if limit else ""
@@ -77,9 +77,9 @@ def glam_style_histogram(
     probe_string = (", \n    ").join(probe_locations)
 
     # 0 <= sample_id < 100
-    for f in np.arange(10, scaled_sample + 10, 10):
+    for f in np.arange(10, scaled_batch_size + 10, 10):
         print(f)
-        if sample_rate:
+        if batch_size:
             sample_id_string = f"AND sample_id >= {int(f - 10)} AND sample_id < {int(f)}"
         else:
             sample_id_string = ""

--- a/src/glam.rs
+++ b/src/glam.rs
@@ -169,7 +169,7 @@ fn fill_buckets(hist: &mut HashMap<usize, f64>, buckets: &[usize]) {
 /// These are distinct sets, and the Glean set are predefined based on the type
 /// of histogram as defined in Glean
 fn calculate_dirichlet_distribution(
-    histogram_vector: HashMap<usize, f64>,
+    histogram_vector: &HashMap<usize, f64>,
     histogram_type: String,
     n_reporting: f64,
     positional_zero: usize,
@@ -195,8 +195,8 @@ fn calculate_dirichlet_distribution(
     // 6.generate the array of all bucket values we need to fill in and
     // add the dirichlet transfromed value (5) to the appropriate bucket
     //
-    let mut hist = histogram_vector; // when we take the dictionary in from Python,
-                                     // we probably cannot take it as a reference
+    let mut hist = histogram_vector.to_owned(); // when we take the dictionary in from Python,
+                                                // we probably cannot take it as a reference
 
     // assuming at this point I have aggregated, normalized histograms
     let histogram_type = Distribution::from_str(histogram_type.as_str());
@@ -237,59 +237,69 @@ pub fn glam_style_histogram(
     let probe = histogram_metadata.probe.as_str();
     let data: DataFrame = pydf.into();
 
-    let partitioned_data = data.partition_by(["build_id"]).unwrap();
+    let partitioned_data = data.partition_by(["build_id"]).unwrap().to_owned();
+
+    let builds: Vec<(String, HashMap<usize, f64>)> = partitioned_data
+        .iter()
+        .map(|df| {
+            let build_id = df
+                .column("build_id")
+                .unwrap()
+                .str_value(0)
+                .unwrap()
+                .to_string();
+            let client_level_dfs = df.partition_by(["client_id"]).unwrap();
+
+            let mut client_levels = Vec::new();
+            client_level_dfs
+                .par_iter()
+                .map(|d| {
+                    let metric_column = d.select_series([probe]).unwrap();
+
+                    let histograms_raw = metric_column[0]
+                        .utf8()
+                        .unwrap()
+                        .into_iter()
+                        .collect::<Vec<_>>();
+                    let histograms_parsed = parse_main_histograms(histograms_raw);
+
+                    let client_aggregated = map_sum(histograms_parsed);
+                    let client_normed = normalize_histogram_glam(client_aggregated);
+
+                    // client_levels.push(client_normed);
+                    client_normed
+                })
+                .collect_into_vec(&mut client_levels);
+
+            let build_histograms = map_sum(client_levels);
+            (build_id, build_histograms.clone())
+        })
+        .collect();
 
     let mut results = Vec::new();
+    builds
+        .par_iter()
+        .map(|(build_id, build_histograms)| {
+            // this is necessary to stop weird floating point behavior
 
-    for df in partitioned_data {
-        let build_id = df
-            .column("build_id")
-            .unwrap()
-            .str_value(0)
-            .unwrap()
-            .to_string();
-        let client_level_dfs = df.partition_by(["client_id"]).unwrap();
+            let n_reporting = build_histograms.clone().values().sum::<f64>().round();
 
-        let mut client_levels = Vec::new();
+            let dirichlet_transformed_hists = calculate_dirichlet_distribution(
+                build_histograms,
+                histogram_metadata.histogram_type.clone(),
+                n_reporting,
+                histogram_metadata.buckets_for_probe[0],
+                histogram_metadata.buckets_for_probe[1],
+                histogram_metadata.buckets_for_probe[2],
+            )
+            .unwrap();
 
-        client_level_dfs
-            .par_iter()
-            .map(|d| {
-                let metric_column = d.select_series([probe]).unwrap();
+            let result = hist_to_normed_sorted(&dirichlet_transformed_hists);
 
-                let histograms_raw = metric_column[0]
-                    .utf8()
-                    .unwrap()
-                    .into_iter()
-                    .collect::<Vec<_>>();
-                let histograms_parsed = parse_main_histograms(histograms_raw);
+            (build_id.to_owned(), result)
+        })
+        .collect_into_vec(&mut results);
 
-                let client_aggregatted = map_sum(histograms_parsed);
-                let client_normed = normalize_histogram_glam(client_aggregatted);
-
-                // client_levels.push(client_normed);
-                client_normed
-            })
-            .collect_into_vec(&mut client_levels);
-
-        let build_histograms = map_sum(client_levels);
-        // this is necessary to stop weird floating point behavior
-        let n_reporting = build_histograms.clone().values().sum::<f64>().round();
-
-        let dirichlet_transformed_hists = calculate_dirichlet_distribution(
-            build_histograms,
-            histogram_metadata.histogram_type.clone(),
-            n_reporting,
-            histogram_metadata.buckets_for_probe[0],
-            histogram_metadata.buckets_for_probe[1],
-            histogram_metadata.buckets_for_probe[2],
-        )
-        .unwrap();
-
-        let result = hist_to_normed_sorted(&dirichlet_transformed_hists);
-
-        results.push((build_id, result));
-    }
     Ok(results)
 }
 

--- a/src/glam.rs
+++ b/src/glam.rs
@@ -45,11 +45,11 @@ fn normalize_histogram_glam(hist: HashMap<i64, i64>) -> HashMap<usize, f64> {
 fn map_sum<T: Hash + Eq + Copy, U: AddAssign + Copy>(maps: Vec<HashMap<T, U>>) -> HashMap<T, U> {
     let mut result_map = HashMap::new();
 
-    for m in maps {
+    maps.into_iter().for_each(|m| {
         for (k, v) in m {
             result_map.entry(k).and_modify(|y| *y += v).or_insert(v);
         }
-    }
+    });
 
     result_map
 }
@@ -121,7 +121,6 @@ fn generate_linear_buckets(min: usize, max: usize, n_buckets: usize) -> Vec<usiz
 
         result.push(linear_range);
     }
-
     result
 }
 
@@ -266,7 +265,6 @@ pub fn glam_style_histogram(
                     let client_aggregated = map_sum(histograms_parsed);
                     let client_normed = normalize_histogram_glam(client_aggregated);
 
-                    // client_levels.push(client_normed);
                     client_normed
                 })
                 .collect_into_vec(&mut client_levels);
@@ -281,7 +279,6 @@ pub fn glam_style_histogram(
         .par_iter()
         .map(|(build_id, build_histograms)| {
             // this is necessary to stop weird floating point behavior
-
             let n_reporting = build_histograms.clone().values().sum::<f64>().round();
 
             let dirichlet_transformed_hists = calculate_dirichlet_distribution(

--- a/src/glam.rs
+++ b/src/glam.rs
@@ -129,10 +129,7 @@ fn generate_linear_buckets(min: usize, max: usize, n_buckets: usize) -> Vec<usiz
 fn hist_to_normed_sorted(hist: &HashMap<usize, f64>) -> Vec<(usize, f64)> {
     let total = hist.values().sum::<f64>().round();
 
-    let mut normalized: Vec<(usize, f64)> = hist
-        .iter()
-        .map(|(k, v)| (*k as usize, *v / total))
-        .collect();
+    let mut normalized: Vec<(usize, f64)> = hist.iter().map(|(k, v)| (*k, *v / total)).collect();
 
     normalized.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 

--- a/src/glam.rs
+++ b/src/glam.rs
@@ -131,7 +131,7 @@ fn hist_to_normed_sorted(hist: &HashMap<usize, f64>) -> Vec<(usize, f64)> {
 
     let mut normalized: Vec<(usize, f64)> = hist
         .iter()
-        .map(|(k, v)| (*k, *v / total))
+        .map(|(k, v)| (*k as usize, *v / total))
         .collect();
 
     normalized.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());


### PR DESCRIPTION
cc @edugfilho 

My queries are getting queued so I can't really test any more, I thought I had a code regression but no it's BQ making me wait.

This code can take multiple columns and runs samples at 10% at a time. It turns out that this actually seems to improve stability quite a bit; i.e. 10 colums at 10% would finish and 1 column at 100% would not. I used mostly the absolutely most populous columns I could. I think this is a real path towards being able to do 100% of histograms.

```python
results = glam_style_histogram(
    [
        "wr_renderer_time",
        "dns_native_queuing",
        "gc_ms",
        "ssl_time_until_ready",
        "dns_native_lookup_time",
        "cycle_collector_max_pause",
        "http_kbread_per_conn2",
        "gc_pretenure_count_2",
        "network_cache_v2_miss_time_ms",
        "input_event_response_ms",
    ],
    False,
    "2023-01-08",
    limit=None,
    batch_size=None,
    table="mozdata.telemetry.main",
)

```